### PR TITLE
Use Edlib to compute the edit distance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,16 @@ if(NOT futures_POPULATED)
     target_include_directories(futures_headers INTERFACE ${futures_SOURCE_DIR}/source)
 endif()
 
+# edlib
+find_package(edlib CONFIG QUIET)
+if (NOT edlib_FOUND)
+    FetchContent_Declare(edlib URL https://github.com/Martinsos/edlib/archive/refs/tags/v1.2.7.zip)
+    if (NOT edlib_POPULATED)
+        FetchContent_Populate(edlib)
+        add_subdirectory(${edlib_SOURCE_DIR} EXCLUDE_FROM_ALL)
+    endif()
+endif()
+
 #######################################################
 ### Executable                                      ###
 #######################################################
@@ -50,4 +60,5 @@ target_link_libraries(clang-unformat
     Threads::Threads
     fmt::fmt
     futures_headers
+    edlib::edlib
 )

--- a/standalone/levenshtein.cpp
+++ b/standalone/levenshtein.cpp
@@ -6,47 +6,18 @@
 //
 
 #include "levenshtein.hpp"
+#include <edlib.h>
 #include <fstream>
-#include <vector>
 
 std::size_t
 levenshtein_distance(std::string_view s1, std::string_view s2) {
-    // trivial cases
-    const std::size_t m(s1.size());
-    const std::size_t n(s2.size());
-    if (m == 0) {
-        return n;
-    }
-    if (n == 0) {
-        return m;
-    }
-
-    // init costs
-    std::vector<std::size_t> costs(n + 1);
-    for (std::size_t k = 0; k <= n; k++) {
-        costs[k] = k;
-    }
-
-    // iterate s1
-    std::size_t i{ 0 };
-    for (char const &c1: s1) {
-        costs[0] = i + 1;
-        std::size_t corner{ i };
-        std::size_t j{ 0 };
-        for (char const &c2: s2) {
-            std::size_t upper{ costs[j + 1] };
-            if (c1 == c2) {
-                costs[j + 1] = corner;
-            } else {
-                std::size_t t(upper < corner ? upper : corner);
-                costs[j + 1] = (costs[j] < t ? costs[j] : t) + 1;
-            }
-            corner = upper;
-            j++;
-        }
-        i++;
-    }
-    return costs[n];
+    return edlibAlign(
+               s1.data(),
+               s1.size(),
+               s2.data(),
+               s2.size(),
+               edlibDefaultAlignConfig())
+        .editDistance;
 }
 
 std::size_t


### PR DESCRIPTION
When I applied clang-unformat to a code base consisting of 158 C++ files with 51k LOC, it took more than 10 hours on a Core i7 laptop to generate the configuration file, and on an Apple M1 Max it still took 3 h 41 min to complete (both with 8 threads in parallel). Profiling revealed that most of the time is spent calculating the Levenshtein distances. This patch replaces the original algorithm by a call to the corresponding function in Edlib (https://github.com/Martinsos/edlib).

On the Core i7 the patched version of clang-unformat with `--parallel 8` takes 21m:41s to complete, and on the M1 the runtime is reduced to 4m:26s.