### PR TITLE
Fixes EdlibAlignResult memory leak

### DIFF
--- a/standalone/levenshtein.cpp
+++ b/standalone/levenshtein.cpp
@@ -6,18 +6,21 @@
 //
 
 #include "levenshtein.hpp"
+#include <cstddef>
 #include <edlib.h>
 #include <fstream>
 
 std::size_t
 levenshtein_distance(std::string_view s1, std::string_view s2) {
-    return edlibAlign(
+    auto r = edlibAlign(
                s1.data(),
                s1.size(),
                s2.data(),
                s2.size(),
-               edlibDefaultAlignConfig())
-        .editDistance;
+               edlibDefaultAlignConfig());
+    std::size_t d = r.editDistance;
+    edlibFreeAlignResult(r);
+    return d;
 }
 
 std::size_t


### PR DESCRIPTION
Hi Alan, thanks for this nice piece of software!

`edlib` README quite misleading in its first snipped of code suggesting a memory leak. Downwards it explains that the result of `edlibAlign` must be freed. See https://github.com/Martinsos/edlib#handling-result-of-edlibalign

It's a C API after all.
This PR wraps the `EdlibAlignResult` into a local struct to ensure calling `edlibFreeAlignResult` at scope exit.

The screenshot below shows `heaptrack` analyzing the output data of the `clang-unformat` program running with the same parameters mentioned in #3 .

![Screenshot from 2023-02-05 07-56-48](https://user-images.githubusercontent.com/11138291/216815733-9694466b-ef11-4465-b18e-17ed8bb98925.png)

Fixes #3 